### PR TITLE
Minor tweaks to get app building without visual studio or prior dependency installations

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "VideoPortalSpa",
   "version": "0.0.0",
   "description": "SPA prototype for Video Portal UX",
-  "main": "index.js",
+  "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
@@ -14,6 +14,9 @@
   "license": "ISC",
   "bugs": {
     "url": "https://github.com/robmhoward/VideoPortalSpa/issues"
+  },
+  "dependencies": {
+    "express": "4.12.*"
   },
   "homepage": "https://github.com/robmhoward/VideoPortalSpa"
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "url": "https://github.com/robmhoward/VideoPortalSpa/issues"
   },
   "dependencies": {
-    "express": "4.12.*"
+    "express": "4.12.*",
+    "angular": "1.3.*"
   },
   "homepage": "https://github.com/robmhoward/VideoPortalSpa"
 }

--- a/server.js
+++ b/server.js
@@ -4,4 +4,6 @@ var app = express();
 
 app.use('/', express.static(__dirname + "/public"));
 
+
+console.log("Starting server on port " + port + "...");
 app.listen(port);


### PR DESCRIPTION
1. Introduced immediately-visible dependencies to package.json so `npm install` works
2. Fixed `npm start` and `node .` by updating main in package.json
3. Output port via console on start for convenience
